### PR TITLE
Default switch value to false if undefined

### DIFF
--- a/src/bulma/VueSwitch.vue
+++ b/src/bulma/VueSwitch.vue
@@ -25,8 +25,8 @@ export default {
         },
         value: {
             type: [Boolean, Number],
-            default: false,
             required: true,
+            default: false,
         },
     },
 

--- a/src/bulma/VueSwitch.vue
+++ b/src/bulma/VueSwitch.vue
@@ -25,6 +25,7 @@ export default {
         },
         value: {
             type: [Boolean, Number],
+            default: false,
             required: true,
         },
     },


### PR DESCRIPTION
[Boolean, Number] apparently breaks "propB" type undefined check ([Prop Validation docs](https://vuejs.org/v2/guide/components-props.html#Prop-Validation))
Defaulting to false fixes it (and should be a safe default for a checkbox)